### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # 2048
+
+This is a simple implementation of the classic 2048 puzzle built with Expo and React Native.
+
+## Prerequisites
+
+- Node.js installed on your machine
+- npm (comes with Node.js)
+
+## Installation
+
+Install the project dependencies:
+
+```bash
+npm install
+```
+
+## Running the game
+
+Start the Expo development server:
+
+```bash
+npm run dev
+```
+
+Expo will provide instructions in the terminal for running the app on a simulator or a physical device. For more details on using Expo, see the [official documentation](https://docs.expo.dev/).


### PR DESCRIPTION
## Summary
- expand README with a project overview and setup instructions

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_682cff13848483238e3c83fbe5dff048