### PR TITLE
Allow custom win target

### DIFF
--- a/context/GameContext.tsx
+++ b/context/GameContext.tsx
@@ -28,6 +28,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     return {
       grid: initialGrid,
       size: 4,
+      targetValue: 2048,
       over: false,
       won: false,
       keepPlaying: false,
@@ -84,14 +85,20 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
   }, [bestScore]);
 
   // Initialize game with two random tiles
-  const initGame = useCallback(() => {
-    let newGrid = createGrid(4);
+  const initGame = useCallback((boardSize = 4) => {
+    let targetValue = 2048;
+    if (boardSize === 3) targetValue = 1024;
+    else if (boardSize === 5) targetValue = 4096;
+    else if (boardSize >= 6) targetValue = 8192;
+
+    let newGrid = createGrid(boardSize);
     newGrid = addRandomTile(newGrid);
     newGrid = addRandomTile(newGrid);
-    
+
     setGameState({
       grid: newGrid,
-      size: 4,
+      size: boardSize,
+      targetValue,
       over: false,
       won: false,
       keepPlaying: false,
@@ -136,7 +143,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       }
       
       // Check if won
-      const won = checkWin(grid) && !gameState.won;
+      const won = checkWin(grid, gameState.targetValue) && !gameState.won;
       
       // Check if game over
       const over = !won && checkGameOver(grid, gameState.size);

--- a/types/game.ts
+++ b/types/game.ts
@@ -28,6 +28,7 @@ export interface Grid {
 export interface GameState {
   grid: Grid;
   size: number;
+  targetValue: number;
   over: boolean;
   won: boolean;
   keepPlaying: boolean;

--- a/utils/gameUtils.ts
+++ b/utils/gameUtils.ts
@@ -243,15 +243,15 @@ export function checkGameOver(grid: Grid, size: number): boolean {
 }
 
 // Check if player has won
-export function checkWin(grid: Grid): boolean {
+export function checkWin(grid: Grid, target = 2048): boolean {
   for (let x = 0; x < grid.size; x++) {
     for (let y = 0; y < grid.size; y++) {
       const tile = grid.cells[x][y];
-      if (tile && tile.value === 2048) {
+      if (tile && tile.value === target) {
         return true;
       }
     }
   }
-  
+
   return false;
 }


### PR DESCRIPTION
## Summary
- expose target param in `checkWin`
- track target value in `GameState`
- compute target in `initGame` based on board size
- use `gameState.targetValue` when checking for a win

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing modules and JSX config)*

------
https://chatgpt.com/codex/tasks/task_e_682cff05bd488323a90b58b999b1550a